### PR TITLE
sched: clean up the algorithm of the basic scheduler

### DIFF
--- a/src/sched/basic.c
+++ b/src/sched/basic.c
@@ -91,13 +91,12 @@ static int sched_init(ABT_sched sched, ABT_sched_config config)
 static void sched_run(ABT_sched sched)
 {
     ABTI_local *p_local = ABTI_local_get_local();
-    uint32_t work_count = 0;
+    uint32_t pop_count = 0;
     sched_data *p_data;
     uint32_t event_freq;
     int num_pools;
     ABT_pool *pools;
     int i;
-    CNT_DECL(run_cnt);
 
     ABTI_xstream *p_xstream = p_local->p_xstream;
     ABTI_sched *p_sched = ABTI_sched_get_ptr(sched);
@@ -107,31 +106,24 @@ static void sched_run(ABT_sched sched)
     event_freq = p_data->event_freq;
     num_pools  = p_data->num_pools;
     pools      = p_data->pools;
+    ABT_unit unit = ABT_UNIT_NULL;
 
     while (1) {
-        CNT_INIT(run_cnt, 0);
-
-        /* Execute one work unit from the scheduler's pool */
-        for (i = 0; i < num_pools; i++) {
-            ABT_pool pool = pools[i];
-            ABTI_pool *p_pool = ABTI_pool_get_ptr(pool);
-            /* Pop one work unit */
-            ABT_unit unit = ABTI_pool_pop(p_pool);
-            if (unit != ABT_UNIT_NULL) {
+        for (int j = 0; j < num_pools; j++) {
+            ABTI_pool *p_pool = ABTI_pool_get_ptr(pools[j]);
+            ++pop_count;
+            if ((unit = ABTI_pool_pop(p_pool)) != ABT_UNIT_NULL) {
                 ABTI_xstream_run_unit(&p_local, p_xstream, unit, p_pool);
-                CNT_INC(run_cnt);
                 break;
             }
         }
-
-        if (++work_count >= event_freq) {
+        /* if we attempted event_freq pops, check for events */
+        if (pop_count >= event_freq) {
             ABTI_xstream_check_events(p_xstream, sched);
-            ABT_bool stop = ABTI_sched_has_to_stop(&p_local, p_sched,
-                                                   p_xstream);
-            if (stop == ABT_TRUE)
+            if (ABTI_sched_has_to_stop(&p_local, p_sched, p_xstream) == ABT_TRUE)
                 break;
-            work_count = 0;
-            SCHED_SLEEP(run_cnt, p_data->sleep_time);
+            SCHED_SLEEP(unit != ABT_UNIT_NULL, p_data->sleep_time);
+            pop_count = 0;
         }
     }
 }


### PR DESCRIPTION
This PR changes the algorithm of the basic scheduler to count the number of pops for every pool.
It checks for events after X ULTs rather than X passes through all the pools. 

Also, this PR removed the `run_cnt` variable used to sleep the scheduler replacing it with a single line of code.

This PR is same as #131 (which is closed due to unrelated commit history).